### PR TITLE
ci: 更新 GitHub Actions 工作流中的 actions 版本

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Clean and prepare directories
         run: |
@@ -34,14 +34,14 @@ jobs:
           mv dist/* preview/dist/
         
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
         # TODO: 配置自定义域名
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'preview'
           
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
将 actions/checkout、actions/configure-pages、actions/upload-pages-artifact 和 actions/deploy-pages 的版本从 v3 和 v2 更新至 v4，以确保使用最新的功能和修复