### PR TITLE
ci(workflow): 将upload-pages-artifact从v4降级到v3

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -38,7 +38,7 @@ jobs:
         # TODO: 配置自定义域名
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'preview'
           


### PR DESCRIPTION
由于兼容性问题，将GitHub Actions中的upload-pages-artifact从v4降级到v3，以确保构建流程的稳定性。