### PR TITLE
fix(icons): 修复图标预览页面中脚本路径错误

### DIFF
--- a/preview/icons/index.html
+++ b/preview/icons/index.html
@@ -462,9 +462,9 @@
     </div>
     <div class="icon-grid" id="iconGrid"></div>
     <!-- </div> -->
-    <script type="module" src="./dist/all.js"></script>
+    <script type="module" src="/dist/all.js"></script>
     <script type="module">
-        import { allIcons, getIcon } from './dist/all.js';
+        import { allIcons, getIcon } from '/dist/all.js';
 
         function initializeDemo() {
             // Replace listAvialaIcons(false) with direct usage of allIcons


### PR DESCRIPTION
修复了图标预览页面中脚本路径的错误，将相对路径改为绝对路径，以确保页面正确加载所需的JavaScript文件。