### PR TITLE
fix(icons): 修复图标预览页面中脚本路径错误

### DIFF
--- a/preview/icons/index.html
+++ b/preview/icons/index.html
@@ -462,9 +462,9 @@
     </div>
     <div class="icon-grid" id="iconGrid"></div>
     <!-- </div> -->
-    <script type="module" src="/dist/all.js"></script>
+    <script type="module" src="/icons/dist/all.js"></script>
     <script type="module">
-        import { allIcons, getIcon } from '/dist/all.js';
+        import { allIcons, getIcon } from '/icons/dist/all.js';
 
         function initializeDemo() {
             // Replace listAvialaIcons(false) with direct usage of allIcons


### PR DESCRIPTION
更新了图标预览页面中脚本的导入路径，确保正确加载图标资源